### PR TITLE
Update get_version() for the final time.

### DIFF
--- a/lib/2take1 compat.lua
+++ b/lib/2take1 compat.lua
@@ -828,7 +828,7 @@ menu = {
 		return true
 	end,
 	get_version = function ()
-		return "2.110.0"
+		return "2.115.0"
 	end
 }
 


### PR DESCRIPTION
Realistically doesn't matter, but 2.115.0 was the final public version of 2take1.